### PR TITLE
Fixed intermediate dir produced by dockerize.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,5 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
 <table width="100%" border="0" summary="list of modules">
-<tr><td><a href="https://github.com/emedia-project/jorel/blob/master/doc/jorel.md" class="module">jorel</a></td></tr></table>
+<tr><td><a href="https://github.com/emedia-project/jorel/blob/build_dir/doc/jorel.md" class="module">jorel</a></td></tr></table>
 

--- a/templates/upgrade_escript.dtl
+++ b/templates/upgrade_escript.dtl
@@ -46,7 +46,7 @@ main(["install", RelName, NodeName, Cookie, Version]) ->
           install_and_permafy(TargetNode, RelName, Vsn);
         {error, UnpackReason} ->
           print_existing_versions(TargetNode),
-          ?INFO("Unpack failed: ~s~n",[UnpackReason]),
+          ?INFO("Unpack failed: ~p~n",[UnpackReason]),
           erlang:halt(2)
       end;
     old ->

--- a/test/jorel_release_app_elixir_tests.erl
+++ b/test/jorel_release_app_elixir_tests.erl
@@ -16,7 +16,7 @@ jorel_release_jorel_elixir_test_() ->
           ?assertEqual(ok, bucfile:make_dir(".tests/0.0.1")),
           ?assertEqual(ok, bucfile:copy("test_apps/0.0.1/elixir_test", ".tests/0.0.1", [recursive])),
           ?assertEqual(ok, bucfile:make_dir(".tests/0.0.1/elixir_test/.jorel")),
-          ?assertEqual(ok, bucfile:copy("jorel", ".tests/0.0.1/elixir_test/.jorel/jorel"))
+          ?assertEqual(ok, bucfile:copy("jorel", ".tests/0.0.1/elixir_test/.jorel/"))
       end}
      , {timeout, 200, 
         fun() ->

--- a/test/jorel_release_app_tests.erl
+++ b/test/jorel_release_app_tests.erl
@@ -61,12 +61,12 @@ jorel_release_jorel_sample_test_() ->
             ?assertEqual(ok, bucfile:copy("test_apps/0.0.2/jorel_sample", ".tests/0.0.2", [recursive])),
             ?assertEqual(ok, bucfile:make_dir(".tests/0.0.2/jorel_sample/.jorel")),
             ?assertEqual(ok, bucfile:copy("jorel", ".tests/0.0.2/jorel_sample/.jorel/")),
-            ?assertEqual(ok, bucfile:copy(".tests/0.0.1/jorel_sample/_jorel", ".tests/0.0.2/jorel_sample", [recursive])),
+            ?assertEqual(ok, bucfile:copy(".tests/0.0.1/jorel_sample/_jorel", ".tests/0.0.2/jorel_sample/", [recursive])),
             ?assertMatch({ok, _}, 
                          sh:sh("make jorel.release",
                                [return_on_error, {cd, ".tests/0.0.2/jorel_sample"}])),
             ?assertEqual(ok, bucfile:copy(".tests/0.0.2/jorel_sample/_jorel/jorel_sample/releases/jorel_sample-0.0.2.tar.gz",
-                                          ".tests/0.0.1/jorel_sample/_jorel/jorel_sample/releases/jorel_sample-0.0.2.tar.gz"))
+                                          ".tests/0.0.1/jorel_sample/_jorel/jorel_sample/releases/"))
         end}
      , {timeout, 200, 
         fun() ->

--- a/test/jorel_release_app_tests.erl
+++ b/test/jorel_release_app_tests.erl
@@ -16,7 +16,7 @@ jorel_release_jorel_sample_test_() ->
           ?assertEqual(ok, bucfile:make_dir(".tests/0.0.1")),
           ?assertEqual(ok, bucfile:copy("test_apps/0.0.1/jorel_sample", ".tests/0.0.1", [recursive])),
           ?assertEqual(ok, bucfile:make_dir(".tests/0.0.1/jorel_sample/.jorel")),
-          ?assertEqual(ok, bucfile:copy("jorel", ".tests/0.0.1/jorel_sample/.jorel/jorel"))
+          ?assertEqual(ok, bucfile:copy("jorel", ".tests/0.0.1/jorel_sample/.jorel/"))
       end}
      , {timeout, 200, 
         fun() ->
@@ -60,7 +60,7 @@ jorel_release_jorel_sample_test_() ->
             ?assertEqual(ok, bucfile:make_dir(".tests/0.0.2")),
             ?assertEqual(ok, bucfile:copy("test_apps/0.0.2/jorel_sample", ".tests/0.0.2", [recursive])),
             ?assertEqual(ok, bucfile:make_dir(".tests/0.0.2/jorel_sample/.jorel")),
-            ?assertEqual(ok, bucfile:copy("jorel", ".tests/0.0.2/jorel_sample/.jorel/jorel")),
+            ?assertEqual(ok, bucfile:copy("jorel", ".tests/0.0.2/jorel_sample/.jorel/")),
             ?assertEqual(ok, bucfile:copy(".tests/0.0.1/jorel_sample/_jorel", ".tests/0.0.2/jorel_sample", [recursive])),
             ?assertMatch({ok, _}, 
                          sh:sh("make jorel.release",


### PR DESCRIPTION
Build dir fixed in jorel_provider_dockerize : was written in a place at build time, and read in another one, at release time
- Tests repaired following changes in bucfile:copy/2 (that may need some repair too ?)
